### PR TITLE
ci: allow commiting version.json file to the repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 # vendor/
 
 *.json
+!version.json


### PR DESCRIPTION
The new [versioning workflow](https://github.com/protocol/.github/blob/master/VERSIONING.md#using-the-versioning-workflows) introduced by unified CI needs to commit `version.json` file to the repository.

This PR will allow adding unified versioning to this repository.